### PR TITLE
Dyn

### DIFF
--- a/debian/dj64-dev-static.install
+++ b/debian/dj64-dev-static.install
@@ -1,2 +1,4 @@
+usr/i386-pc-dj64/lib/libc.a
 usr/i386-pc-dj64/lib64/*.a
 usr/share/pkgconfig/dj64_s.pc
+usr/share/pkgconfig/dj64static.pc

--- a/debian/dj64-dev.install
+++ b/debian/dj64-dev.install
@@ -1,10 +1,9 @@
 usr/i386-pc-dj64/include
-usr/i386-pc-dj64/lib/libc.a
+usr/i386-pc-dj64/lib/*.o
 usr/i386-pc-dj64/lib64/*.so
 usr/i386-pc-dj64/bin/*
 usr/i386-pc-dj64/share/*
 usr/bin/*
 usr/share/pkgconfig/dj64.pc
-usr/share/pkgconfig/dj64static.pc
 usr/share/man/man1/*
 usr/share/doc/dj64/*

--- a/dj64.mk
+++ b/dj64.mk
@@ -61,12 +61,13 @@ endif
 endif
 
 ifneq ($(AS_OBJECTS),)
-XLDFLAGS = -melf_i386
+XLDFLAGS = -melf_i386 -static
 ifeq ($(DJ64STATIC),1)
-XLDFLAGS += $(shell pkg-config --static --libs dj64static) -static
+XLDFLAGS += $(shell pkg-config --static --libs dj64static)
 DJ64_XLDFLAGS += -f 0x4000
 else
-XLDFLAGS += -shared -z notext
+XLDFLAGS += $(shell pkg-config --variable=crt0 dj64) \
+  --section-start=.note.gnu.property=0x08148000 -section-start=.text=0x08149000
 endif
 $(XELF): $(AS_OBJECTS) $(PLT_O)
 	$(XLD) $^ $(XLDFLAGS) -o $@

--- a/dj64.mk
+++ b/dj64.mk
@@ -61,11 +61,17 @@ endif
 endif
 
 ifneq ($(AS_OBJECTS),)
-XLDFLAGS = $(shell pkg-config --static --libs dj64static) -melf_i386 -static
+XLDFLAGS = -melf_i386
+ifeq ($(DJ64STATIC),1)
+XLDFLAGS += $(shell pkg-config --static --libs dj64static) -static
+DJ64_XLDFLAGS += -f 0x4000
+else
+XLDFLAGS += -shared -z notext
+endif
 $(XELF): $(AS_OBJECTS) $(PLT_O)
 	$(XLD) $^ $(XLDFLAGS) -o $@
 	$(XSTRIP) $@
-DJ64_XLDFLAGS += -l $(XELF) -f 0x4000
+DJ64_XLDFLAGS += -l $(XELF)
 else
 ifeq ($(DJ64STATIC),1)
 DJ64_XLDFLAGS += -l $(shell pkg-config --variable=crt0 dj64_s) -f 0x4000

--- a/dj64.pc.in
+++ b/dj64.pc.in
@@ -4,5 +4,6 @@ Version: @VERSION@
 prefix=@PREFIX@
 makeinc=${prefix}/i386-pc-dj64/share/dj64.mk
 cppflags=-I${prefix}/i386-pc-dj64/include -DDJ64
+crt0=${prefix}/i386-pc-dj64/lib/uplt.o
 Cflags: -fpic
 Libs: -L${prefix}/i386-pc-dj64/lib64 -ldj64 -shared -Wl,-Bsymbolic

--- a/dj64.spec.rpkg
+++ b/dj64.spec.rpkg
@@ -78,13 +78,12 @@ This package contains tools and headers for building dj64-enabled programs.
 %files dj64-devel
 %defattr(-,root,root)
 %{_prefix}/i386-pc-dj64/include
-%{_prefix}/i386-pc-dj64/lib/libc.a
+%{_prefix}/i386-pc-dj64/lib/*.o
 %{_prefix}/i386-pc-dj64/lib64/*.so
 %{_prefix}/i386-pc-dj64/bin/*
 %{_prefix}/i386-pc-dj64/share/*
 %{_bindir}/*
 %{_datadir}/pkgconfig/dj64.pc
-%{_datadir}/pkgconfig/dj64static.pc
 %{_mandir}/man1/*
 %{_docdir}/dj64
 %end
@@ -100,8 +99,10 @@ May be needed on non-glibc systems.
 
 %files dj64-devel-static
 %defattr(-,root,root)
+%{_prefix}/i386-pc-dj64/lib/libc.a
 %{_prefix}/i386-pc-dj64/lib64/*.a
 %{_datadir}/pkgconfig/dj64_s.pc
+%{_datadir}/pkgconfig/dj64static.pc
 %end
 
 %package djdev64

--- a/include/libc/stubinfo.h
+++ b/include/libc/stubinfo.h
@@ -27,7 +27,8 @@
 #define STUBINFO_PAYLOAD2_NAME 0x74
 #define STUBINFO_MEM_BASE 0x88
 #define STUBINFO_FLAGS 0x8C
-#define STUBINFO_END 0x90
+#define STUBINFO_UENTRY 0x90
+#define STUBINFO_END 0x94
 #ifndef __ASSEMBLER__
 #include <stdint.h>
 typedef struct {
@@ -57,6 +58,7 @@ typedef struct {
   char payload2_name[20];
   uint32_t mem_base;
   uint32_t flags;
+  uint32_t uentry;
 } _GO32_StubInfo;
 
 _Static_assert(sizeof(_GO32_StubInfo) == STUBINFO_END, "size mismatch");

--- a/makefile
+++ b/makefile
@@ -6,6 +6,7 @@ INSTALL ?= install
 VERSION = 0.1
 DJLIBC = $(TOP)/lib/libc.a
 DJCRT0 = $(TOP)/lib/crt0.elf
+DJUCRT0 = $(TOP)/lib/uplt.o
 DJ64LIB = $(TOP)/lib/libdj64.so.*.*
 DJ64DEVL = $(TOP)/lib/libdj64.so
 DJ64LIBS = $(TOP)/lib/libdj64_s.a
@@ -66,6 +67,7 @@ install_dj64:
 	$(INSTALL) -d $(DESTDIR)$(PREFIX)/i386-pc-dj64/lib
 	$(INSTALL) -m 0644 $(DJLIBC) $(DESTDIR)$(PREFIX)/i386-pc-dj64/lib
 	$(INSTALL) -m 0644 $(DJCRT0) $(DESTDIR)$(PREFIX)/i386-pc-dj64/lib
+	$(INSTALL) -m 0644 $(DJUCRT0) $(DESTDIR)$(PREFIX)/i386-pc-dj64/lib
 	$(INSTALL) -d $(DESTDIR)$(PREFIX)/i386-pc-dj64/lib64
 	$(INSTALL) $(DJ64LIB) $(DESTDIR)$(PREFIX)/i386-pc-dj64/lib64
 	cp -fP $(DJ64DEVL) $(DESTDIR)$(PREFIX)/i386-pc-dj64/lib64

--- a/src/djdev64/stub/stub.c
+++ b/src/djdev64/stub/stub.c
@@ -340,6 +340,7 @@ int djstub_main(int argc, char *argv[], char *envp[], unsigned psp_sel,
         handle = ops->read_headers(ifile);
         if (!handle)
             exit(EXIT_FAILURE);
+        stubinfo.uentry = ops->get_entry(handle);
         va2 = ops->get_va(handle);
         va_size2 = ops->get_length(handle);
         stub_debug("va 0x%x va_size 0x%x\n", va2, va_size2);
@@ -387,7 +388,7 @@ int djstub_main(int argc, char *argv[], char *envp[], unsigned psp_sel,
     dosops->_dos_seek(ifile, noffset, SEEK_SET);
     if (nsize > 0)
         stub_debug("Found payload of size %i at 0x%x\n", nsize, noffset);
-    stubinfo.stubinfo_ver |= 3;
+    stubinfo.stubinfo_ver |= 4;
 
     unregister_dpmiops();
 

--- a/src/libc/dj64/makefile
+++ b/src/libc/dj64/makefile
@@ -56,7 +56,8 @@ thunks_a.o: asm_incs.h plt_asmc.h asym_incs.h
 thunks_c.o: thunk_incs.h thunk_calls.h
 thunks_p.o: thunk_incs.h thunk_asms.h
 
-plt.o: plt.S plt.inc
+plt.o: plt.S plt.inc plt_defs.inc
+uplt.o: uplt.S plt_defs.inc
 
 ALL_OBJS = $(addprefix ../,$(file < $(TOP)/makefile.rf))
 $(LIB)/$(LIBN): $(TOP)/makefile.rf $(ALL_OBJS) \
@@ -82,10 +83,14 @@ $(LIB)/crt0.elf: $(LIB)/libc.a
 	$(CROSS_ASSTRIP) --strip-debug $@
 	chmod -x $@
 
+$(LIB)/uplt.o: uplt.o
+	cp $< $@
+
 $(LIB)/libdj64.so: $(LIB)/$(LIBN) | $(LIB)
 	ln -sf $(LIBN) $@
 
-final: $(LIB)/libc.a $(LIB)/libdj64.so $(LIB)/$(LIBS) $(LIB)/crt0.elf | $(LIB)
+final: $(LIB)/libc.a $(LIB)/libdj64.so $(LIB)/$(LIBS) $(LIB)/crt0.elf \
+  $(LIB)/uplt.o | $(LIB)
 
 clean::
 	$(RM) rm *.a *.tmp *.inc asm_*.h thunk_*.h plt_*.h asym_incs.h

--- a/src/libc/dj64/plt.S
+++ b/src/libc/dj64/plt.S
@@ -244,6 +244,7 @@ plt_init:
     movl $1, %eax
     int $0x31
     /* call manager */
+    movl %fs:STUBINFO_FLAGS, %eax
     movl maddr, %ebx
     movl %fs:STUBINFO_SELF_SIZE, %ecx
     movl %fs:STUBINFO_MEM_BASE, %edx

--- a/src/libc/dj64/plt.S
+++ b/src/libc/dj64/plt.S
@@ -19,6 +19,7 @@
 #include <libc/asmdefs.h>
 #include "stubinfo.h"
 #include "plt.h"
+.include "plt_defs.inc"
 
 .bss
 
@@ -29,8 +30,6 @@ __plt_call: .quad 0
 __plt_ctrl: .quad 0
 .global __plt_handle
 __plt_handle: .long 0
-AUX_CORE = 0
-AUX_USER = 1
 
 sel: .word 0
 SHM_REQ_LEN = 0
@@ -60,12 +59,6 @@ err_str: .asciz "dj64: load failure\r\n$"
 
 .text
 
-.macro call_plt
-    movl __plt_handle, %eax
-    movl $0, %esi  // reserved
-    lcalll *__plt_call
-.endm
-
 .macro asmcfunc_n nm,num
     .global _\nm
     _\nm:
@@ -81,12 +74,14 @@ err_str: .asciz "dj64: load failure\r\n$"
     ret
 .endm
 
-#include "plt.inc"
+.include "plt.inc"
 
-.global dj64_plt_call
-dj64_plt_call:
-    movl $AUX_USER, %ebx
-    call_plt
+uplt_init:
+    pushl __plt_handle
+    pushl __plt_call + 4
+    pushl __plt_call
+    call *%fs:STUBINFO_UENTRY
+    addl $12, %esp
     ret
 
 .global plt_init
@@ -190,7 +185,11 @@ plt_init:
     movl %edi, __plt_call
     movl %eax, __plt_ctrl + 4
     movl %esi, __plt_ctrl
-
+    movl %fs:STUBINFO_FLAGS, %ecx
+    testw $0x4080, %cx
+    jnz 111f
+    call uplt_init
+111:
     movl %fs:STUBINFO_SELF_SIZE, %ecx
     orl %ecx, %ecx
     jz 3f

--- a/src/libc/dj64/plt_defs.inc
+++ b/src/libc/dj64/plt_defs.inc
@@ -1,0 +1,16 @@
+AUX_CORE = 0
+AUX_USER = 1
+
+.macro call_plt
+    movl __plt_handle, %eax
+    movl $0, %esi  # reserved
+    lcalll *__plt_call
+.endm
+
+.text
+
+.global dj64_plt_call
+dj64_plt_call:
+    movl $AUX_USER, %ebx
+    call_plt
+    ret

--- a/src/libc/dj64/uplt.S
+++ b/src/libc/dj64/uplt.S
@@ -1,0 +1,19 @@
+#include <libc/asmdefs.h>
+.include "plt_defs.inc"
+
+.bss
+
+__plt_call: .quad 0
+__plt_handle: .long 0
+
+.text
+
+.global _start
+_start:
+    movl 4(%esp), %eax
+    movl %eax, __plt_call
+    movl 8(%esp), %eax
+    movl %eax, __plt_call + 4
+    movl 12(%esp), %eax
+    movl %eax,  __plt_handle
+    ret


### PR DESCRIPTION
This adds "proper" dynamic linking support.
Well, a kind of.
As usual, I've found some tricks to
avoid writing the real dynamic linker...
But at least now it works, and comcom64.exe
shrinks by 30Kb.